### PR TITLE
Reload update Pt. 2

### DIFF
--- a/gui_text_vals.py
+++ b/gui_text_vals.py
@@ -24,3 +24,5 @@ title_text5 = game_fonts.con_font2.render(varGClinefour, True, (255, 0, 0))
 backtext = game_fonts.smallfont.render('BACK', True, button1_color_light) #create object for back button text
 reloadingtext = game_fonts.font.render('[R] to Reload', True, (255, 0, 0))
 reloadingtext_empty = game_fonts.guifont.render('No Ammo To Reload. Collect Ammo Drops', True, (255, 0, 0))
+reloadinprogresstext_cantreload = game_fonts.guifont.render('You Are Already Reloading', True, (255, 0, 0))
+reloadinprogresstext_cantshoot = game_fonts.guifont.render("You Can't Shoot While Reloading", True, (255, 0, 0))

--- a/main.py
+++ b/main.py
@@ -5,6 +5,10 @@ from variables import *
 from threading import Thread #to implement reload timer
 from threading import Lock #to implement reload timer data passing
 
+
+last_reload_time = 0
+reload_delay = 2000
+
 lock = Lock() #should enable me to pass info to and from threads
 
 console_debugging = False #change this to True to enable debugging log in console
@@ -590,25 +594,30 @@ def main(settings): #function to handle the main game loop
             if console_debugging: #debug output
                     print('player pressed R')
             if player.ammo_reserve > 0 and player.ammo_count < settings.player_magazine_size: #if player can shoot
-                global timingreload, can_reload, checkthread
+                global timingreload, can_reload, checkthread, last_reload_time, reload_delay
                 #calculate how many rounds to reload
+                current_time = pygame.time.get_ticks()
                 rounds_to_reload = min(settings.player_magazine_size - player.ammo_count, player.ammo_reserve)  # Calculate how many rounds needed to fill the magazine
                 #update ammo_count and ammo_reserve variables
                 
+                if current_time - last_reload_time >= reload_delay:
+                    print("reloading")
+                    
                 ##time logic##
-                timingreload = True 
-                checkthread = True
+                #timingreload = True 
+                #checkthread = True
                 
-                if console_debugging:
-                    print(f'can reload is: {can_reload}')
+                    if console_debugging:
+                        print(f'can reload is: {can_reload}')
                 
                 #time.sleep(2) #causes a stutter to simulate reload time
 
-                if console_debugging: #debug output
-                    print('playing reload sound')
-                sound_reloading()
-                player.ammo_count += rounds_to_reload
-                player.ammo_reserve -= rounds_to_reload
+                    if console_debugging: #debug output
+                        print('playing reload sound')
+                    sound_reloading()
+                    player.ammo_count += rounds_to_reload
+                    player.ammo_reserve -= rounds_to_reload
+                    last_reload_time = current_time
 
         #updating bullet positions
         for bullet in bullets[:]:  #use a copy of the list to avoid unwanted modifications

--- a/main.py
+++ b/main.py
@@ -6,10 +6,10 @@ from variables import *
 console_debugging = False #change this to True to enable debugging log in console
 
 last_reload_time = 0
-reload_delay = 2000
-shoot_delay = 1000
+reload_delay = 1500
+shoot_delay = 500
 reload_completion_time = 0
-
+reloaderrors_spam = False 
 
 clock = pygame.time.Clock() #to implement frame limit
 
@@ -152,6 +152,19 @@ def spawn_points_init():
 #end function defs
 
 #class defs
+class ReloadErrors:
+    def draw(self, surface):
+        import gui_text_vals
+        messageisvisible = True
+
+        #while messageisvisible:
+        #    surface.blit(gui_text_vals.reloadinprogresstext_cantshoot, (width // 2 - gui_text_vals.reloadingtext_empty.get_width() // 2, height // 4))
+        #    current_time3 = pygame.time.get_ticks()
+        #    msg_delay = 1000
+        #    if current_time3 >= msg_delay:
+        #        messageisvisible = False
+
+    
 class InputHandler: #handle 'Global' game key inputs (accessible anywhere in the game)
     def __init__(self):
         self.fullscreen_key = pygame.K_F11 #set the full screen toggle key to F11
@@ -548,7 +561,13 @@ def main(settings): #function to handle the main game loop
                         print('player triggered shoot')
                     if current_time2 - reload_completion_time >= shoot_delay:
                         sound_shooting()
-                        player.shoot() #execute the shoot method from the player class 
+                        player.shoot() #execute the shoot method from the player class
+                    elif current_time2 - reload_completion_time < shoot_delay:
+                        global reloaderrors_spam
+                        if console_debugging:
+                            print('you cant shoot while reloading')
+                        reloaderrors_spam = True 
+                        
                 if event.key == pygame.K_ESCAPE: #if user hits escape key
                     if console_debugging: #debug output
                         print('player pressed ESC')
@@ -688,6 +707,8 @@ def main(settings): #function to handle the main game loop
             if console_debugging:    
                 print('player needs to reload')
                 print('reload message displaying')
+        if reloaderrors_spam:
+            ReloadErrors_obj.draw(ReloadErrors, window)
     
         #drawing bullets
         for bullet in bullets:
@@ -718,6 +739,7 @@ def main(settings): #function to handle the main game loop
 #define init objects
 settings = GameSettings() #create settings obj
 scaling = ScaleSettings() #define scaling from ScaleSettings class (imported)
+ReloadErrors_obj = ReloadErrors
 
 #run init functions
 load_images() #execute load_images function

--- a/main.py
+++ b/main.py
@@ -17,7 +17,8 @@ checkthread = False
 #define threading functions
 def threaded_reload_timer(timingreload, can_reload, checkthread):
     import time 
-    print('thread running')
+    if console_debugging:
+        print('thread running')
     while checkthread == True: #i cant get updated vars passed to this thread
         if timingreload == True:
             if console_debugging:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ from variables import *
 from threading import Thread #to implement reload timer
 from threading import Lock #to implement reload timer data passing
 
-
 last_reload_time = 0
 reload_delay = 2000
 

--- a/reload_control.py
+++ b/reload_control.py
@@ -1,0 +1,2 @@
+shoot_delay = 1000
+reload_delay = 3000

--- a/reload_control.py
+++ b/reload_control.py
@@ -1,2 +1,0 @@
-shoot_delay = 1000
-reload_delay = 3000


### PR DESCRIPTION
Rewrote a lot of reloading logic and finally made it impossible for player to spam reload, in addition to making a small timer elapse between reloading and firing again to simulate a full reload to the player.
Bega incorporating GUI prompts about the reloading system, namely telling the player that they can't fire while reloading, and that they can't reload while reloading. Also removed everything connected to the previous attempted implementation of threading, and time, as neither were needed for the implementation that worked.